### PR TITLE
add frame fade animations

### DIFF
--- a/DinksUI.lua
+++ b/DinksUI.lua
@@ -66,7 +66,7 @@ local options = {
 		buffFrame = { type = "input", name = "Buff Frame", desc = "BuffFrame", width = "full", order = 28 },
 		debuffFrame = { type = "input", name = "Debuff Frame", desc = "DebuffFrame", width = "full", order = 29 },
 		experienceBar = { type = "input", name = "Experience Bar", desc = "MainStatusTrackingBarContainer", width = "full", order = 30 },
-		skyRidingBar = { type = "input", name = "Sky Riding Bar", desc = "UIWidgetPowerBarContainerFrame", width = "full", order = 31 },
+		encounterBar = { type = "input", name = "EncounterBar / Sky Riding Bar", desc = "EncounterBar", width = "full", order = 31 },
 
 		bottomBlank = { type = "description", name = " ", fontSize = "medium", order = 97 },
 		bottomReloadTxt = { type = "description", name = "You will need to activate after confirming changes.", fontSize = "medium", order = 98 },
@@ -109,7 +109,7 @@ local defaults = {
 		buffFrame = "",
 		debuffFrame = "",
 		experienceBar = "[mod:ctrl][mod:alt][combat] show; hide",
-		skyRidingBar = "[mod:ctrl][mod:alt][combat] show; hide",
+		encounterBar = "[mod:ctrl][mod:alt][combat] show; hide",
 	},
 }
 
@@ -212,7 +212,7 @@ function DinksUI:RegisterAllFrames()
 	self:Register(frames.buffFrame.desc, conditionals.buffFrame)
 	self:Register(frames.debuffFrame.desc, conditionals.debuffFrame)
 	self:Register(frames.experienceBar.desc, conditionals.experienceBar)
-	self:Register(frames.skyRidingBar.desc, conditionals.skyRidingBar)
+	self:Register(frames.encounterBar.desc, conditionals.encounterBar)
 end
 
 -- Remember to also add new frames here as well.
@@ -242,7 +242,7 @@ function DinksUI:UnregisterAllFrames()
 	self:Unregister(frames.buffFrame.desc)
 	self:Unregister(frames.debuffFrame.desc)
 	self:Unregister(frames.experienceBar.desc)
-	self:Unregister(frames.skyRidingBar.desc)
+	self:Unregister(frames.encounterBar.desc)
 end
 
 function DinksUI:Register(frameKey, conditionalMacro)
@@ -304,26 +304,26 @@ function DinksUI:CreateNewParentFrame()
 	local fadeInAlpha = fadeIn:CreateAnimation("Alpha")
 	fadeInAlpha:SetFromAlpha(0)
 	fadeInAlpha:SetToAlpha(1)
-	fadeInAlpha:SetDuration(0.1)
+	fadeInAlpha:SetDuration(0.125)
 	fadeInAlpha:SetSmoothing("IN")
 
-	-- Fade-out animations don't seem to work with this method of hiding frames.
-	-- local fadeOut = newParent:CreateAnimationGroup()
-	-- local fadeOutAlpha = fadeOut:CreateAnimation("Alpha")
-	-- fadeOutAlpha:SetFromAlpha(1)
-	-- fadeOutAlpha:SetToAlpha(0)
-	-- fadeOutAlpha:SetDuration(0.5)
-	-- fadeOutAlpha:SetSmoothing("OUT")
+	-- Fade-out animations don't seem to work with this method of hiding frames...
+	local fadeOut = newParent:CreateAnimationGroup()
+	local fadeOutAlpha = fadeOut:CreateAnimation("Alpha")
+	fadeOutAlpha:SetFromAlpha(1)
+	fadeOutAlpha:SetToAlpha(0)
+	fadeOutAlpha:SetDuration(0.5)
+	fadeOutAlpha:SetSmoothing("OUT")
 
 	newParent:SetScript("OnShow", function(self)
-		-- fadeOut:Stop()
+		fadeOut:Stop()
 		fadeIn:Play()
 	end)
 
-	-- newParent:SetScript("OnHide", function(self)
-	-- 	fadeIn:Stop()
-	-- 	fadeOut:Play()
-	-- end)
+	newParent:SetScript("OnHide", function(self)
+		fadeIn:Stop()
+		fadeOut:Play()
+	end)
 
 	return newParent
 end

--- a/DinksUI.lua
+++ b/DinksUI.lua
@@ -250,7 +250,7 @@ function DinksUI:Register(frameKey, conditionalMacro)
 		-- Save the original parent for `DinksUI.Unregister`.
 		-- If the frame was registered already and never unregistered, take the saved original parent.
 		local oldParent = FrameWrapperTable[frameKey] or _G[frameKey]:GetParent()
-		local newParent = CreateFrame("Frame", nil, UIParent, "SecureHandlerStateTemplate")
+		local newParent = self:CreateNewParentFrame()
 
 		_G[frameKey]:SetParent(newParent)
 		FrameWrapperTable[frameKey] = oldParent
@@ -258,11 +258,13 @@ function DinksUI:Register(frameKey, conditionalMacro)
 	end
 end
 
+-- Because chat can have any number of windows, we need a more dynamic method.
 function DinksUI:RegisterChat(frameKey, conditionalMacro)
 	for i = 1, NUM_CHAT_WINDOWS do
 		self:Register(frameKey .. i, conditionalMacro)
 	end
 
+	-- Chat kind of also includes those buttons to the left.
 	self:Register("GeneralDockManager", conditionalMacro)
 	self:Register("QuickJoinToastButton", conditionalMacro)
 end
@@ -276,12 +278,10 @@ function DinksUI:Unregister(frameKey)
 end
 
 function DinksUI:UnregisterChat(frameKey, conditionalMacro)
-	-- Because chat can have any number of windows, we need a more dynamic method.
 	for i = 1, NUM_CHAT_WINDOWS do
 		self:Unregister(frameKey .. i)
 	end
 
-	-- Chat kind of also includes those buttons to the left.
 	self:Unregister("GeneralDockManager")
 	self:Unregister("QuickJoinToastButton")
 end
@@ -295,6 +295,37 @@ end
 
 function DinksUI:SetValue(info, value)
 	self.db.profile[info[#info]] = value
+end
+
+function DinksUI:CreateNewParentFrame()
+	local newParent = CreateFrame("Frame", nil, UIParent, "SecureHandlerStateTemplate")
+	-- Set up fade-in and fade-out animations
+	local fadeIn = newParent:CreateAnimationGroup()
+	local fadeInAlpha = fadeIn:CreateAnimation("Alpha")
+	fadeInAlpha:SetFromAlpha(0)
+	fadeInAlpha:SetToAlpha(1)
+	fadeInAlpha:SetDuration(0.1)
+	fadeInAlpha:SetSmoothing("IN")
+
+	-- Fade-out animations don't seem to work with this method of hiding frames.
+	-- local fadeOut = newParent:CreateAnimationGroup()
+	-- local fadeOutAlpha = fadeOut:CreateAnimation("Alpha")
+	-- fadeOutAlpha:SetFromAlpha(1)
+	-- fadeOutAlpha:SetToAlpha(0)
+	-- fadeOutAlpha:SetDuration(0.5)
+	-- fadeOutAlpha:SetSmoothing("OUT")
+
+	newParent:SetScript("OnShow", function(self)
+		-- fadeOut:Stop()
+		fadeIn:Play()
+	end)
+
+	-- newParent:SetScript("OnHide", function(self)
+	-- 	fadeIn:Stop()
+	-- 	fadeOut:Play()
+	-- end)
+
+	return newParent
 end
 
 ------------------------------------------

--- a/DinksUI.toc
+++ b/DinksUI.toc
@@ -2,7 +2,7 @@
 ## Title: Dinks' Immersive UI
 ## Notes: My custom UI hiding addon.
 ## Author: Duenke
-## Version: 1.0.3
+## Version: 1.0.5
 ## SavedVariables: DinksUIDB
 ## IconTexture: Interface\ICONS\Ability_mage_greaterinvisibility
 


### PR DESCRIPTION
- ✨ add fade-in animation to smooth out transitions
  - for some reason, fade-out doesn't seem to work with this method of hiding frames
- 🐛 swap `UIWidgetPowerBarContainerFrame` for container, `EncounterBar`, due to bug
  - skyriding bar was not showing up some of the time